### PR TITLE
bumpversion to bump2version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 cython
 pytest
 pytest-cov
-bumpversion>=0.5.3
+bump2version


### PR DESCRIPTION
- [bumpversion](https://github.com/peritus/bumpversion) appears to be not be maintained
- [bump2version](https://github.com/c4urself/bump2version) appears to be a great drop-in replacement
- just a qol for calling bumpversion from python3s